### PR TITLE
.NET Standard 2.0 に変更

### DIFF
--- a/MDSound/MDSound/MDSound.csproj
+++ b/MDSound/MDSound/MDSound.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyTitle>MDSound</AssemblyTitle>
     <Product>MDSound</Product>
     <Copyright>Copyright ©  2016</Copyright>
@@ -17,10 +17,6 @@
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
   <ItemGroup>
     <Content Include="fmgen\readme.txt" />
   </ItemGroup>

--- a/MDSound/MDSound/MDSound.csproj
+++ b/MDSound/MDSound/MDSound.csproj
@@ -1,143 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{87A99ABD-5F5F-4221-83E3-741BD8D3692E}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>MDSound</RootNamespace>
-    <AssemblyName>MDSound</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFramework>net40</TargetFramework>
+    <AssemblyTitle>MDSound</AssemblyTitle>
+    <Product>MDSound</Product>
+    <Copyright>Copyright ©  2016</Copyright>
+    <DefineConstants />
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>
-    </DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>
-    </DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ay8910.cs" />
-    <Compile Include="c140.cs" />
-    <Compile Include="c352.cs" />
-    <Compile Include="common.cs" />
-    <Compile Include="fmgen\file.cs" />
-    <Compile Include="fmgen\fmgen.cs" />
-    <Compile Include="fmgen\opm.cs" />
-    <Compile Include="fmgen\opna.cs" />
-    <Compile Include="fmvgen\ADPCMB.cs" />
-    <Compile Include="fmvgen\FM6.cs" />
-    <Compile Include="fmvgen\fmvgen.cs" />
-    <Compile Include="fmvgen\opna2.cs" />
-    <Compile Include="fmgen\psg.cs" />
-    <Compile Include="fmvgen\psg2.cs" />
-    <Compile Include="fmgen\Timer.cs" />
-    <Compile Include="gb.cs" />
-    <Compile Include="Instrument.cs" />
-    <Compile Include="iremga20.cs" />
-    <Compile Include="K051649.cs" />
-    <Compile Include="K053260.cs" />
-    <Compile Include="K054539.cs" />
-    <Compile Include="MDSound.cs" />
-    <Compile Include="mpcmX68k.cs" />
-    <Compile Include="multipcm.cs" />
-    <Compile Include="nes_intf.cs" />
-    <Compile Include="np\chip\emu2149.cs" />
-    <Compile Include="np\chip\emu2413.cs" />
-    <Compile Include="np\chip\IDeviceInfo.cs" />
-    <Compile Include="np\chip\nes_apu.cs" />
-    <Compile Include="np\chip\nes_dmc.cs" />
-    <Compile Include="np\chip\nes_fds.cs" />
-    <Compile Include="np\chip\nes_fme7.cs" />
-    <Compile Include="np\chip\nes_mmc5.cs" />
-    <Compile Include="np\chip\nes_n106.cs" />
-    <Compile Include="np\chip\nes_vrc6.cs" />
-    <Compile Include="np\chip\nes_vrc7.cs" />
-    <Compile Include="np\cpu\km6502.cs" />
-    <Compile Include="np\detect.cs" />
-    <Compile Include="np\IDevice.cs" />
-    <Compile Include="np\memory\nes_bank.cs" />
-    <Compile Include="np\memory\nes_mem.cs" />
-    <Compile Include="np\np_nes_apu.cs" />
-    <Compile Include="np\np_nes_dmc.cs" />
-    <Compile Include="np\np_nes_fds.cs" />
-    <Compile Include="okim6258.cs" />
-    <Compile Include="okim6295.cs" />
-    <Compile Include="Ootake_PSG.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="pwm.cs" />
-    <Compile Include="qsound.cs" />
-    <Compile Include="rf5c68.cs" />
-    <Compile Include="scd_pcm.cs" />
-    <Compile Include="segapcm.cs" />
-    <Compile Include="sn76489.cs" />
-    <Compile Include="X68Sound\adpcm.cs" />
-    <Compile Include="X68Sound\global.cs" />
-    <Compile Include="X68Sound\lfo.cs" />
-    <Compile Include="X68Sound\NX68Sound.cs" />
-    <Compile Include="X68Sound\op.cs" />
-    <Compile Include="X68Sound\opm.cs" />
-    <Compile Include="X68Sound\Pcm8.cs" />
-    <Compile Include="X68Sound\sound_iocs.cs" />
-    <Compile Include="y8950.cs" />
-    <Compile Include="ym2151.cs" />
-    <Compile Include="ym2151_mame.cs" />
-    <Compile Include="ym2151_x68sound.cs" />
-    <Compile Include="ym2203.cs" />
-    <Compile Include="ym2413.cs" />
-    <Compile Include="ym2608.cs" />
-    <Compile Include="ym2609.cs" />
-    <Compile Include="ym2610.cs" />
-    <Compile Include="ym2612.cs" />
-    <Compile Include="ym3438.cs" />
-    <Compile Include="ym3438_const.cs" />
-    <Compile Include="ym3526.cs" />
-    <Compile Include="ym3812.cs" />
-    <Compile Include="ymf262.cs" />
-    <Compile Include="ymf271.cs" />
-    <Compile Include="ymf278b.cs" />
-    <Compile Include="ymz280b.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="fmgen\readme.txt" />
   </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/MDSound/MDSound/Properties/AssemblyInfo.cs
+++ b/MDSound/MDSound/Properties/AssemblyInfo.cs
@@ -2,18 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
-// アセンブリに関連付けられている情報を変更するには、
-// これらの属性値を変更してください。
-[assembly: AssemblyTitle("MDSound")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("MDSound")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // ComVisible を false に設定すると、その型はこのアセンブリ内で COM コンポーネントから 
 // 参照不可能になります。COM からこのアセンブリ内の型にアクセスする場合は、
 // その型の ComVisible 属性を true に設定してください。
@@ -21,16 +9,3 @@ using System.Runtime.InteropServices;
 
 // このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
 [assembly: Guid("87a99abd-5f5f-4221-83e3-741bd8d3692e")]
-
-// アセンブリのバージョン情報は次の 4 つの値で構成されています:
-//
-//      メジャー バージョン
-//      マイナー バージョン
-//      ビルド番号
-//      Revision
-//
-// すべての値を指定するか、下のように '*' を使ってビルドおよびリビジョン番号を 
-// 既定値にすることができます:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MDSound/test/Properties/AssemblyInfo.cs
+++ b/MDSound/test/Properties/AssemblyInfo.cs
@@ -2,18 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
-// アセンブリに関連付けられている情報を変更するには、
-// これらの属性値を変更してください。
-[assembly: AssemblyTitle("test")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("test")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // ComVisible を false に設定すると、その型はこのアセンブリ内で COM コンポーネントから 
 // 参照不可能になります。COM からこのアセンブリ内の型にアクセスする場合は、
 // その型の ComVisible 属性を true に設定してください。
@@ -21,16 +9,3 @@ using System.Runtime.InteropServices;
 
 // このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
 [assembly: Guid("5a99e426-0920-499e-a293-7ecbfff39008")]
-
-// アセンブリのバージョン情報は次の 4 つの値で構成されています:
-//
-//      メジャー バージョン
-//      マイナー バージョン
-//      ビルド番号
-//      Revision
-//
-// すべての値を指定するか、下のように '*' を使ってビルドおよびリビジョン番号を 
-// 既定値にすることができます:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MDSound/test/test.csproj
+++ b/MDSound/test/test.csproj
@@ -1,16 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>test</AssemblyTitle>
     <Product>test</Product>
     <Copyright>Copyright ©  2016</Copyright>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <PlatformTarget>x86</PlatformTarget>
-    <PostBuildEvent>copy "$(ProjectDir)lib"\*.dll "$(TargetDir)"</PostBuildEvent>
-    <PostBuildEvent>copy "$(ProjectDir)lib"\*.dll "$(TargetDir)"</PostBuildEvent>
-    <PostBuildEvent>copy "$(ProjectDir)lib"\*.dll "$(TargetDir)"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -19,9 +16,9 @@
     <DebugType>pdbonly</DebugType>
     <DefineConstants />
   </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>copy "$(ProjectDir)lib"\*.dll "$(TargetDir)"</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="copy &quot;$(ProjectDir)lib\*.dll&quot; &quot;$(TargetDir)&quot;" />
+  </Target>
   <ItemGroup>
     <Reference Include="RealChipCtlWrap, Version=0.0.0.0, Culture=neutral, processorArchitecture=x86">
       <HintPath>lib\RealChipCtlWrap.dll</HintPath>

--- a/MDSound/test/test.csproj
+++ b/MDSound/test/test.csproj
@@ -1,91 +1,57 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{5A99E426-0920-499E-A293-7ECBFFF39008}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>test</RootNamespace>
-    <AssemblyName>test</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>net40</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworkProfile />
+    <AssemblyTitle>test</AssemblyTitle>
+    <Product>test</Product>
+    <Copyright>Copyright ©  2016</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <PlatformTarget>x86</PlatformTarget>
+    <PostBuildEvent>copy "$(ProjectDir)lib"\*.dll "$(TargetDir)"</PostBuildEvent>
+    <PostBuildEvent>copy "$(ProjectDir)lib"\*.dll "$(TargetDir)"</PostBuildEvent>
+    <PostBuildEvent>copy "$(ProjectDir)lib"\*.dll "$(TargetDir)"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>
-    </DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <DefineConstants />
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>copy "$(ProjectDir)lib"\*.dll "$(TargetDir)"</PostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="RealChipCtlWrap, Version=0.0.0.0, Culture=neutral, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>lib\RealChipCtlWrap.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="SdlDotNet, Version=6.1.0.0, Culture=neutral, PublicKeyToken=26ad4f7e10c61408, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>lib\SdlDotNet.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="SoundManager\BaseMakerSender.cs" />
-    <Compile Include="SoundManager\BaseSender.cs" />
-    <Compile Include="SoundManager\ChipSender.cs" />
-    <Compile Include="Common.cs" />
-    <Compile Include="SoundManager\DataMaker.cs" />
-    <Compile Include="SoundManager\DataSender.cs" />
-    <Compile Include="SoundManager\DriverAction.cs" />
-    <Compile Include="frmMain.cs">
+    <Compile Update="frmMain.cs">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="frmMain.Designer.cs">
+    <Compile Update="frmMain.Designer.cs">
       <DependentUpon>frmMain.cs</DependentUpon>
     </Compile>
-    <Compile Include="log.cs" />
-    <Compile Include="SoundManager\EmuChipSender.cs" />
-    <Compile Include="SoundManager\Pack.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RealChip.cs" />
-    <Compile Include="SoundManager\RealChipSender.cs" />
-    <Compile Include="SoundManager\RingBuffer.cs" />
-    <Compile Include="SoundManager\SoundManager.cs" />
-    <EmbeddedResource Include="frmMain.resx">
+    <EmbeddedResource Update="frmMain.resx">
       <DependentUpon>frmMain.cs</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.resx">
+    <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <Compile Include="Properties\Resources.Designer.cs">
+    <Compile Update="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
@@ -100,20 +66,14 @@
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
-    <Compile Include="Properties\Settings.Designer.cs">
+    <Compile Update="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\MDSound\MDSound.csproj">
-      <Project>{87a99abd-5f5f-4221-83e3-741bd8d3692e}</Project>
-      <Name>MDSound</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\MDSound\MDSound.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="lib\c86ctl.dll">
@@ -133,15 +93,4 @@
     <Content Include="lib\SDL_mixer.dll" />
     <Content Include="lib\Tao.Sdl.dll" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy "$(ProjectDir)lib"\*.dll "$(TargetDir)"</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>


### PR DESCRIPTION
.NET Standard は様々な .NET 環境での共通 API 仕様です。

https://docs.microsoft.com/ja-jp/dotnet/standard/net-standard

これに準拠することにより、 Windows 以外の様々なプラットフォームでも実行できるようになります。
変更前は .NET v4.0 でしたので、 .NET Standard 2.0 とすると .NET Framework としては v4.6.1 以上の対応となり、変更前より対応バージョンを上げることになります。
個人的には特に問題ないと考えていますが、考慮していたたげればと思います。